### PR TITLE
wiki API 수정

### DIFF
--- a/src/main/java/com/example/demo/base/exception/ExceptionCode.java
+++ b/src/main/java/com/example/demo/base/exception/ExceptionCode.java
@@ -28,10 +28,15 @@ public enum ExceptionCode {
     DUPLICATE_NAME(HttpStatus.BAD_REQUEST, "중복된 이름이 존재합니다."),
     EMPTY_LOCATION(HttpStatus.BAD_REQUEST, "위치정보가 존재하지 않습니다."),
     EMPTY_SOLUTION(HttpStatus.BAD_REQUEST, "배출방법이 존재하지 않습니다."),
-    EMPTY_WIKI(HttpStatus.BAD_REQUEST, "위키가 존재하지 않습니다."),
     WASTE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "해당 폐기물 정보를 찾을 수 없습니다."),
     TAG_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "해당 태그 정보를 찾을 수 없습니다."),
-    EXIST_WIKI(HttpStatus.INTERNAL_SERVER_ERROR, "사용자가 작성한 검토중인 위키가 존재합니다.");
+
+
+    //wiki
+    EMPTY_WIKI(HttpStatus.NOT_FOUND, "해당 위키가 존재하지 않습니다."),
+    EXIST_WIKI(HttpStatus.CONFLICT, "해당 배출정보의 보류 상태인 사용자의 위키가 존재합니다."),
+    NOT_PENDING_WIKI(HttpStatus.CONFLICT, "반영 및 거부된 위키는 수정 또는 삭제가 불가능합니다."),
+    INVALID_WIKI_WRITER(HttpStatus.FORBIDDEN, "해당 위키의 작성자가 아닌 경우 위키의 수정 또는 삭제가 불가능합니다.");
 
     private HttpStatus status;
     private String message;

--- a/src/main/java/com/example/demo/bounded_context/account/controller/AccountController.java
+++ b/src/main/java/com/example/demo/bounded_context/account/controller/AccountController.java
@@ -37,7 +37,7 @@ public class AccountController {
     @GetMapping("/me")
     @Operation(summary = "정보 조회", description = "access token 을 사용한 사용자 정보 조회")
     public ResponseEntity<AccountResponse> read(@AuthorizationHeader Long id) {
-        Account account = accountService.findByAccountId(id);
+        Account account = accountService.read(id);
         AccountResponse accountResponse = AccountResponse.fromEntity(account);
         return ResponseEntity.ok().body(accountResponse);
     }

--- a/src/main/java/com/example/demo/bounded_context/account/dto/AccountResponse.java
+++ b/src/main/java/com/example/demo/bounded_context/account/dto/AccountResponse.java
@@ -1,13 +1,17 @@
 package com.example.demo.bounded_context.account.dto;
 
 import com.example.demo.bounded_context.account.entity.Account;
+import com.example.demo.bounded_context.wiki.dto.WikiListResponse;
+
+import java.util.List;
 
 public record AccountResponse(
         String accountName,
         String email,
         String nickname,
         Double latitude,
-        Double longitude
+        Double longitude,
+        List<WikiListResponse> wikis
 ) {
 
     public static AccountResponse fromEntity(Account account){
@@ -16,7 +20,8 @@ public record AccountResponse(
                 account.getEmail(),
                 account.getNickname(),
                 account.getLatitude(),
-                account.getLongitude()
+                account.getLongitude(),
+                account.getWikis().stream().map(WikiListResponse::fromEntity).toList()
                 );
     }
 }

--- a/src/main/java/com/example/demo/bounded_context/account/entity/Account.java
+++ b/src/main/java/com/example/demo/bounded_context/account/entity/Account.java
@@ -3,8 +3,12 @@ package com.example.demo.bounded_context.account.entity;
 
 import com.example.demo.base.common.BaseTimeEntity;
 import com.example.demo.bounded_context.account.dto.AccountUpdateRequest;
+import com.example.demo.bounded_context.wiki.entity.Wiki;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -25,6 +29,9 @@ public class Account extends BaseTimeEntity {
     private Double latitude;
 
     private Double longitude;
+
+    @OneToMany(mappedBy = "writer")
+    private List<Wiki> wikis = new ArrayList<>();
 
     @Builder
     public Account(String accountName, String password, String email, String nickname, Double latitude, Double longitude) {

--- a/src/main/java/com/example/demo/bounded_context/account/repository/AccountRepository.java
+++ b/src/main/java/com/example/demo/bounded_context/account/repository/AccountRepository.java
@@ -2,6 +2,7 @@ package com.example.demo.bounded_context.account.repository;
 
 import com.example.demo.bounded_context.account.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,4 +10,7 @@ import java.util.Optional;
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
     Optional<Account> findByAccountName(String accountName);
+
+    @Query("select a from Account a left join fetch a.wikis where a.id = :accountId")
+    Optional<Account> findFetchByAccountId(Long accountId);
 }

--- a/src/main/java/com/example/demo/bounded_context/account/service/AccountService.java
+++ b/src/main/java/com/example/demo/bounded_context/account/service/AccountService.java
@@ -32,6 +32,12 @@ public class AccountService {
                 .orElseThrow(() -> new CustomException(ExceptionCode.ACCOUNT_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
+    public Account findFetchByAccountId(Long accountId){
+        return accountRepository.findFetchByAccountId(accountId)
+                .orElseThrow(() -> new CustomException(ExceptionCode.ACCOUNT_NOT_FOUND));
+    }
+
     /**
      * 로그아웃
      * 1. access token 정보로 blacklist token 생성
@@ -54,6 +60,11 @@ public class AccountService {
         RefreshToken refresh = validateRefreshTokenOwnership(accessToken, refreshToken);
         refreshTokenService.remove(refresh.getAccountId());
         accountRepository.deleteById(refresh.getAccountId());
+    }
+
+    @Transactional(readOnly = true)
+    public Account read(Long accountId){
+        return findFetchByAccountId(accountId);
     }
 
     @Transactional

--- a/src/main/java/com/example/demo/bounded_context/solution/dto/SolutionResponse.java
+++ b/src/main/java/com/example/demo/bounded_context/solution/dto/SolutionResponse.java
@@ -3,6 +3,7 @@ package com.example.demo.bounded_context.solution.dto;
 import com.example.demo.bounded_context.solution.entity.Category;
 import com.example.demo.bounded_context.solution.entity.Tag;
 import com.example.demo.bounded_context.solution.entity.Waste;
+import com.example.demo.bounded_context.wiki.dto.WikiListResponse;
 
 import java.util.List;
 

--- a/src/main/java/com/example/demo/bounded_context/solution/entity/Waste.java
+++ b/src/main/java/com/example/demo/bounded_context/solution/entity/Waste.java
@@ -1,5 +1,6 @@
 package com.example.demo.bounded_context.solution.entity;
 
+import com.example.demo.bounded_context.wiki.entity.Wiki;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/example/demo/bounded_context/solution/entity/Waste.java
+++ b/src/main/java/com/example/demo/bounded_context/solution/entity/Waste.java
@@ -33,8 +33,7 @@ public class Waste {
 
     private String imageUrl;
 
-    public void update(String name, String solution) {
-        this.name = name;
+    public void update(String solution) {
         this.solution = solution;
     }
 }

--- a/src/main/java/com/example/demo/bounded_context/wiki/api/WikiApi.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/api/WikiApi.java
@@ -1,0 +1,122 @@
+package com.example.demo.bounded_context.wiki.api;
+
+import com.example.demo.base.Resolver.AuthorizationHeader;
+import com.example.demo.bounded_context.wiki.dto.WikiRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Wiki", description = "위키 관련 API")
+public interface WikiApi {
+    @PostMapping("/api/solution/{wasteId}/wiki")
+    @Operation(summary = "위키 요청 생성", description = "로그인한 사용자는 기존 배출정보에 대한 위키 요청을 생성할 수 있다.<br> 카테고리, 태그, 솔루션에 대한 위키 요청을 생성할 수 있다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "위키 생성 성공"),
+            @ApiResponse(responseCode = "409", description = "위키 생성 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    										{
+                                    										"timestamp": "2024-06-04T21:07:08.923528",
+                                                                            "cause": "EXIST_WIKI",
+                                                                            "message": "해당 배출정보의 보류 상태인 사용자의 위키가 존재합니다."
+                                    										}
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "500", description = "위키 생성 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    										{
+                                    										"timestamp": "2024-06-04T21:07:08.923528",
+                                                                            "cause": "ConstraintViolationException",
+                                                                            "message": "빈 필드 값이 존재합니다."
+                                    										}
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> create(@AuthorizationHeader Long accountId,
+                                @PathVariable("wasteId") Long wasteId,
+                                @RequestBody WikiRequest request);
+
+    @GetMapping("/api/wiki/{wikiId}")
+    @Operation(summary = "위키 정보 조회", description = "모든 사용자는 위키 정보를 조회하고 이전 버전과 비교할 수 있다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "위키 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "위키 조회 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    										{
+                                    										"timestamp": "2024-06-04T21:07:08.923528",
+                                                                            "cause": "EMPTY_WIKI",
+                                                                            "message": "해당 위키가 존재하지 않습니다."
+                                    										}
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> read(@PathVariable("wikiId") Long wikiId);
+
+    @DeleteMapping("/api/wiki/{wikiId}")
+    @Operation(summary = "위키 정보 삭제", description = "로그인한 사용자 중 위키의 작성자는 위키 요청이 수락 또는 거부되기 전에 생성한 위키 요청를 삭제할 수 있다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "위키 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "위키 삭제 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    										{
+                                    										"timestamp": "2024-06-04T21:07:08.923528",
+                                                                            "cause": "EMPTY_WIKI",
+                                                                            "message": "해당 위키가 존재하지 않습니다."
+                                    										}
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "409", description = "위키 삭제 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    										{
+                                    										"timestamp": "2024-06-04T21:07:08.923528",
+                                                                            "cause": "NOT_PENDING_WIKI",
+                                                                            "message": "반영 및 거부된 위키는 수정 또는 삭제가 불가능합니다."
+                                    										}
+                                    """)
+                    })),
+    })
+    ResponseEntity<?> delete(@AuthorizationHeader Long userId,
+                             @PathVariable("wikiId") Long wikiId);
+
+    @PutMapping("/api/wiki/{wikiId}/accepted")
+    @Operation(summary = "위키 요청 승인", description = "관리자는 사용자의 위키 요청을 반영하여 기존 정보를 대체할 수 있다.<br>승인된 위키는 보류중인 위키들의 원본이 된다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "위키 요청 승인 성공"),
+            @ApiResponse(responseCode = "404", description = "위키 요청 승인 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    										{
+                                    										"timestamp": "2024-06-04T21:07:08.923528",
+                                                                            "cause": "EMPTY_WIKI",
+                                                                            "message": "해당 위키가 존재하지 않습니다."
+                                    										}
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> accept(@PathVariable("wikiId") Long wikiId);
+
+    @PutMapping("/api/wiki/{wikiId}/rejected")
+    @Operation(summary = "위키 요청 거부", description = "관리자는 사용자의 위키 요청을 거부할 수 있다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "위키 요청 거부 성공"),
+            @ApiResponse(responseCode = "404", description = "위키 요청 승인 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    										{
+                                    										"timestamp": "2024-06-04T21:07:08.923528",
+                                                                            "cause": "EMPTY_WIKI",
+                                                                            "message": "해당 위키가 존재하지 않습니다."
+                                    										}
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> reject(@PathVariable("wikiId") Long wikiId);
+}

--- a/src/main/java/com/example/demo/bounded_context/wiki/controller/WikiController.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/controller/WikiController.java
@@ -1,6 +1,7 @@
 package com.example.demo.bounded_context.wiki.controller;
 
 import com.example.demo.base.Resolver.AuthorizationHeader;
+import com.example.demo.bounded_context.wiki.api.WikiApi;
 import com.example.demo.bounded_context.account.service.AccountService;
 import com.example.demo.bounded_context.wiki.dto.WikiCompareResponse;
 import com.example.demo.bounded_context.wiki.dto.WikiRequest;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-public class WikiController {
+public class WikiController implements WikiApi {
 
     private final WasteService wasteService;
     private final WikiService wikiService;
@@ -26,12 +27,10 @@ public class WikiController {
      * [o] 부모 위키 연결
      * [x] 쿼리 최적화
      */
-    @PostMapping("/api/solution/{wasteId}/wiki")
-    @Operation(summary = "위키 작성", description = "기존 데이터에 대한 위키 작성")
-    private ResponseEntity<Long> create(@AuthorizationHeader Long writerId,
-                                        @PathVariable("wasteId") Long wasteId,
-                                        @RequestBody WikiRequest request){
-        Wiki wiki = wikiService.create(accountService.findByAccountId(writerId), wasteService.findById(wasteId), request);
+    public ResponseEntity<Long> create(@AuthorizationHeader Long accountId,
+                                       @PathVariable("wasteId") Long wasteId,
+                                       @RequestBody WikiRequest request){
+        Wiki wiki = wikiService.create(accountService.findByAccountId(accountId), wasteService.findById(wasteId), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(wiki.getId());
     }
 
@@ -39,9 +38,7 @@ public class WikiController {
      * [o] 부모 위키와 정보 비교
      * [x] 쿼리 최적화
      */
-    @GetMapping("/api/wiki/{wikiId}")
-    @Operation(summary = "위키 정보 조회", description = "위키 정보 조회")
-    private ResponseEntity<?> read(@PathVariable("wikiId") Long wikiId){
+    public ResponseEntity<WikiCompareResponse> read(@PathVariable("wikiId") Long wikiId){
         WikiCompareResponse response = wikiService.read(wikiId);
         return ResponseEntity.ok().body(response);
     }
@@ -51,9 +48,7 @@ public class WikiController {
      * [o] 위키 작성자 검사
      * [o] 위키 상태 검사
      */
-    @DeleteMapping("/api/wiki/{wikiId}")
-    @Operation(summary = "위키 정보 삭제", description = "위키 정보 삭제")
-    private ResponseEntity<?> delete(@AuthorizationHeader Long userId,
+    public ResponseEntity<?> delete(@AuthorizationHeader Long userId,
                                      @PathVariable("wikiId") Long wikiId){
         wikiService.delete(userId, wikiId);
         return ResponseEntity.ok().body("위키가 삭제되었습니다.");
@@ -65,9 +60,7 @@ public class WikiController {
      * [o] 기존 데이터 대체
      * [x] 쿼리 최적화
      */
-    @PutMapping("/api/wiki/{wikiId}/accepted")
-    @Operation(summary = "위키 정보 승인", description = "위키 정보를 반영하여 기존 데이터 대체")
-    private ResponseEntity<?> accept(@PathVariable("wikiId") Long wikiId){
+    public ResponseEntity<?> accept(@PathVariable("wikiId") Long wikiId){
         wikiService.accept(wikiId);
         return ResponseEntity.ok().body("위키 요청 승인이 완료되었습니다.");
     }
@@ -75,10 +68,12 @@ public class WikiController {
     /**
      * [x] 관리자 권한 검사
      */
-    @PutMapping("/api/wiki/{wikiId}/rejected")
-    @Operation(summary = "위키 정보 거부", description = "위키 정보를 거절")
-    private ResponseEntity<?> reject(@PathVariable("wikiId") Long wikiId){
+    public ResponseEntity<?> reject(@PathVariable("wikiId") Long wikiId){
         wikiService.reject(wikiId);
         return ResponseEntity.ok().body("위키 요청 거부가 완료되었습니다.");
     }
+
+    //readAll : 배출방법의 모든 위키
+    //read wiki : 사용자의 위키 정보
+    //read new wiki : 사용자의 새로운 위키 정보
 }

--- a/src/main/java/com/example/demo/bounded_context/wiki/controller/WikiController.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/controller/WikiController.java
@@ -1,11 +1,11 @@
-package com.example.demo.bounded_context.solution.controller;
+package com.example.demo.bounded_context.wiki.controller;
 
 import com.example.demo.base.Resolver.AuthorizationHeader;
 import com.example.demo.bounded_context.account.service.AccountService;
-import com.example.demo.bounded_context.solution.dto.WikiCompareResponse;
-import com.example.demo.bounded_context.solution.dto.WikiRequest;
-import com.example.demo.bounded_context.solution.entity.Wiki;
-import com.example.demo.bounded_context.solution.service.WikiService;
+import com.example.demo.bounded_context.wiki.dto.WikiCompareResponse;
+import com.example.demo.bounded_context.wiki.dto.WikiRequest;
+import com.example.demo.bounded_context.wiki.entity.Wiki;
+import com.example.demo.bounded_context.wiki.service.WikiService;
 import com.example.demo.bounded_context.solution.service.WasteService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiCompareResponse.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiCompareResponse.java
@@ -1,4 +1,4 @@
-package com.example.demo.bounded_context.solution.dto;
+package com.example.demo.bounded_context.wiki.dto;
 
 public record WikiCompareResponse(
         WikiResponse origin,

--- a/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiListResponse.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiListResponse.java
@@ -1,7 +1,7 @@
-package com.example.demo.bounded_context.solution.dto;
+package com.example.demo.bounded_context.wiki.dto;
 
-import com.example.demo.bounded_context.solution.entity.Wiki;
-import com.example.demo.bounded_context.solution.entity.WikiState;
+import com.example.demo.bounded_context.wiki.entity.Wiki;
+import com.example.demo.bounded_context.wiki.entity.WikiState;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiListResponse.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiListResponse.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 public record WikiListResponse(
         Long wikiId,
         String authorNickName,
+        String wasteName,
         WikiState wikiState,
         LocalDateTime createdDate,
         LocalDateTime modifiedDate
@@ -16,6 +17,7 @@ public record WikiListResponse(
         return new WikiListResponse(
                 wiki.getId(),
                 wiki.getWriter().getNickname(),
+                wiki.getWaste().getName(),
                 wiki.getWikiState(),
                 wiki.getCreatedDate(),
                 wiki.getModifiedDate()

--- a/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiRequest.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiRequest.java
@@ -3,19 +3,23 @@ package com.example.demo.bounded_context.wiki.dto;
 import com.example.demo.bounded_context.account.entity.Account;
 import com.example.demo.bounded_context.wiki.entity.Wiki;
 import com.example.demo.bounded_context.solution.entity.Waste;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+//trim 필요
+@Schema(name = "WikiCreateRequest", description = "위키 생성 요청 DTO")
 public record WikiRequest (
-        String name,
-        String solution,
+        @Schema(description = "카테고리", example = "종이류,비닐류")
         String categories,
-        String tags
+        @Schema(description = "태그", example = "종이백,비닐쇼핑백")
+        String tags,
+        @Schema(description = "배출 솔루션", example = "일반 종이 재질의 쇼핑백은 종이로 분리배출\r\n비닐 쇼핑백은 비닐류로 분리배출")
+        String solution
 ){
-    public Wiki toEntity(Account writer, Waste waste, Wiki parentWiki){
+    public Wiki toEntity(Account writer, Waste waste, Wiki original){
         return Wiki.builder()
                 .writer(writer)
                 .waste(waste)
-                .parent(parentWiki)
-                .name(name)
+                .original(original)
                 .categories(categories)
                 .tags(tags)
                 .solution(solution)

--- a/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiRequest.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiRequest.java
@@ -1,7 +1,7 @@
-package com.example.demo.bounded_context.solution.dto;
+package com.example.demo.bounded_context.wiki.dto;
 
 import com.example.demo.bounded_context.account.entity.Account;
-import com.example.demo.bounded_context.solution.entity.Wiki;
+import com.example.demo.bounded_context.wiki.entity.Wiki;
 import com.example.demo.bounded_context.solution.entity.Waste;
 
 public record WikiRequest (

--- a/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiResponse.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiResponse.java
@@ -8,9 +8,9 @@ import java.time.LocalDateTime;
 public record WikiResponse (
         String writerName,
         String wasteName,
-        String solution,
         String categories,
         String tags,
+        String solution,
         WikiState wikiState,
         LocalDateTime createdDate,
         LocalDateTime modifiedDate
@@ -18,10 +18,10 @@ public record WikiResponse (
     public static WikiResponse fromEntity(Wiki wiki){
         return new WikiResponse(
                 wiki.getWriter().getNickname(),
-                wiki.getName(),
-                wiki.getSolution(),
+                wiki.getWaste().getName(),
                 wiki.getCategories(),
                 wiki.getTags(),
+                wiki.getSolution(),
                 wiki.getWikiState(),
                 wiki.getCreatedDate(),
                 wiki.getModifiedDate()

--- a/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiResponse.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/dto/WikiResponse.java
@@ -1,7 +1,7 @@
-package com.example.demo.bounded_context.solution.dto;
+package com.example.demo.bounded_context.wiki.dto;
 
-import com.example.demo.bounded_context.solution.entity.Wiki;
-import com.example.demo.bounded_context.solution.entity.WikiState;
+import com.example.demo.bounded_context.wiki.entity.Wiki;
+import com.example.demo.bounded_context.wiki.entity.WikiState;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/example/demo/bounded_context/wiki/entity/Wiki.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/entity/Wiki.java
@@ -4,6 +4,7 @@ import com.example.demo.base.common.BaseTimeEntity;
 import com.example.demo.bounded_context.account.entity.Account;
 import com.example.demo.bounded_context.solution.entity.Waste;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,28 +22,34 @@ public class Wiki extends BaseTimeEntity {
     private Waste waste;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Wiki parent;
+    private Wiki original;
 
-    private String name;
+    @NotNull
     private String solution;
+
+    @NotNull
     private String categories;
+
+    @NotNull
     private String tags;
+
     private WikiState wikiState;
 
     @Builder
-    public Wiki(Account writer, Waste waste, String name, String solution, String categories, String tags, Wiki parent) {
+    public Wiki(Account writer, Waste waste, @NotNull String solution, @NotNull String categories, @NotNull String tags, Wiki original) {
         this.writer = writer;
         this.waste = waste;
-        this.name = name;
         this.solution = solution;
         this.categories = categories;
         this.tags = tags;
         this.wikiState = WikiState.PENDING;
-        this.parent = parent;
+        this.original = original;
     }
 
     public void accept(){
         this.wikiState = WikiState.ACCEPTED;
     }
     public void reject() { this.wikiState = WikiState.REJECTED; }
+
+    public void changeOriginal(Wiki original) { this.original = original; }
 }

--- a/src/main/java/com/example/demo/bounded_context/wiki/entity/Wiki.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/entity/Wiki.java
@@ -1,7 +1,8 @@
-package com.example.demo.bounded_context.solution.entity;
+package com.example.demo.bounded_context.wiki.entity;
 
 import com.example.demo.base.common.BaseTimeEntity;
 import com.example.demo.bounded_context.account.entity.Account;
+import com.example.demo.bounded_context.solution.entity.Waste;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/example/demo/bounded_context/wiki/entity/WikiState.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/entity/WikiState.java
@@ -1,4 +1,4 @@
-package com.example.demo.bounded_context.solution.entity;
+package com.example.demo.bounded_context.wiki.entity;
 
 public enum WikiState {
     PENDING, ACCEPTED, REJECTED

--- a/src/main/java/com/example/demo/bounded_context/wiki/repository/WikiRepository.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/repository/WikiRepository.java
@@ -1,6 +1,6 @@
-package com.example.demo.bounded_context.solution.repository;
+package com.example.demo.bounded_context.wiki.repository;
 
-import com.example.demo.bounded_context.solution.entity.Wiki;
+import com.example.demo.bounded_context.wiki.entity.Wiki;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/example/demo/bounded_context/wiki/repository/WikiRepository.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/repository/WikiRepository.java
@@ -1,7 +1,10 @@
 package com.example.demo.bounded_context.wiki.repository;
 
+import com.example.demo.bounded_context.solution.entity.Waste;
 import com.example.demo.bounded_context.wiki.entity.Wiki;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -15,6 +18,11 @@ public interface WikiRepository extends JpaRepository<Wiki, Long> {
     @Query("select w from Wiki w join fetch w.waste t where t.id = :wasteId and w.wikiState = 1 order by w.modifiedDate desc")
     public Optional<Wiki> findByRecent(Long wasteId);
 
-    @Query("select w from Wiki w join fetch w.writer where w.id = :id")
-    public Wiki findFetchById(Long id);
+    @Query("select w from Wiki w join fetch w.writer join fetch w.waste where w.id = :id")
+    public Optional<Wiki> findFetchById(Long id);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Wiki w SET w.original = :original WHERE w.waste = :waste")
+    public void updateOrigin(Wiki original, Waste waste);
 }

--- a/src/main/java/com/example/demo/bounded_context/wiki/service/WikiService.java
+++ b/src/main/java/com/example/demo/bounded_context/wiki/service/WikiService.java
@@ -1,13 +1,16 @@
-package com.example.demo.bounded_context.solution.service;
+package com.example.demo.bounded_context.wiki.service;
 
 import com.example.demo.base.exception.CustomException;
 import com.example.demo.base.exception.ExceptionCode;
 import com.example.demo.bounded_context.account.entity.Account;
-import com.example.demo.bounded_context.solution.dto.WikiCompareResponse;
-import com.example.demo.bounded_context.solution.dto.WikiRequest;
-import com.example.demo.bounded_context.solution.dto.WikiResponse;
+import com.example.demo.bounded_context.wiki.dto.WikiCompareResponse;
+import com.example.demo.bounded_context.wiki.dto.WikiRequest;
+import com.example.demo.bounded_context.wiki.dto.WikiResponse;
 import com.example.demo.bounded_context.solution.entity.*;
-import com.example.demo.bounded_context.solution.repository.WikiRepository;
+import com.example.demo.bounded_context.wiki.repository.WikiRepository;
+import com.example.demo.bounded_context.solution.service.WasteService;
+import com.example.demo.bounded_context.wiki.entity.Wiki;
+import com.example.demo.bounded_context.wiki.entity.WikiState;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
### 작업사항
- 테이블 스키마 변경 : material -> category / opinion -> wiki
- 도메인 분리 : solution / wiki
- wiki service : 예외 추가
- wiki create : name 필드에 대해서는 수정하지 못함
- wiki accept : 보류중인 위키들은 승인된 위키를 다시 원본으로 가지도록
- account read : wiki 내용 포함
- swagger apiresponse 작성 및 wiki controller, api 분리 